### PR TITLE
hotfix-1

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 apply plugin: 'com.google.gms.google-services'
-com.google.gms.googleservices.GoogleServicesPlugin.config.disableVersionCheck = true
+// com.google.gms.googleservices.GoogleServicesPlugin.config.disableVersionCheck = true
 
 android {
     compileSdkVersion 29

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,48 +3,47 @@ import 'package:provider/provider.dart';
 import 'package:sokoni/src/providers/auth.dart';
 import 'package:sokoni/src/screens/Login.dart';
 import 'package:sokoni/src/screens/home.dart';
-import 'package:sokoni/src/widgets/loading.dart';
 import 'package:firebase_core/firebase_core.dart';
 
-void main() async{
+void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp();
   //Multiproviders so that our App can recognize the providers we've used.
 
   runApp(
     MultiProvider(
-      providers:[
-      ChangeNotifierProvider.value(
-      value: AuthProvider.initialize()
-      )
-  ],
-   child:MaterialApp(
-      debugShowCheckedModeBanner: false,
-      title: 'Sokoni',
-      theme: ThemeData(    
-
-        primarySwatch: Colors.blue,
-        visualDensity: VisualDensity.adaptivePlatformDensity,
-         ),
-       home: ScreensController(),
-          )
-  ));
+      providers: [
+        ChangeNotifierProvider(
+          create: (context) => AuthProvider.initialize(),
+        )
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        title: 'Sokoni',
+        theme: ThemeData(
+          primarySwatch: Colors.blue,
+          visualDensity: VisualDensity.adaptivePlatformDensity,
+        ),
+        home: ScreensController(),
+      ),
+    ),
+  );
 }
 
-class ScreensController extends StatelessWidget{
+class ScreensController extends StatelessWidget {
   @override
-  Widget build( BuildContext context) {
-  
+  Widget build(BuildContext context) {
     final user = Provider.of<AuthProvider>(context);
-    switch(user.status){
-      case Status.Uninitialized:
-      return Loading();
+    switch (user.status) {
+      // case Status.Uninitialized:
+      //   return Loading();
       case Status.Unauthenticated:
       case Status.Authenticating:
-      return LoginScreen();
+        return LoginScreen();
       case Status.Authenticated:
-       return HomePage();
-      default: return LoginScreen(); 
+        return HomePage();
+      default:
+        return LoginScreen();
     }
-  } 
+  }
 }

--- a/lib/src/helpers/user.dart
+++ b/lib/src/helpers/user.dart
@@ -1,26 +1,25 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:sokoni/src/models/user.dart';
 
-class UserServices{
+class UserServices {
   String collection = "users";
   // ignore: deprecated_member_use
-  Firestore _firestore = Firestore.instance;
+  FirebaseFirestore _firestore = FirebaseFirestore.instance;
 
-void createUser(Map<String, dynamic> values ){
-  String id = values["id"];
-  // ignore: deprecated_member_use
-  _firestore.collection(collection).document(id).setData(values);
+  void createUser(Map<String, dynamic> values) {
+    String id = values["id"];
+    // ignore: deprecated_member_use
+    _firestore.collection(collection).document(id).setData(values);
+  }
 
-}
-
-void updateUserData(Map<String, dynamic> values ){
-  // ignore: deprecated_member_use
-  _firestore.collection(collection).document(values["id"]).updateData(values);
-}
+  void updateUserData(Map<String, dynamic> values) {
+    // ignore: deprecated_member_use
+    _firestore.collection(collection).document(values["id"]).updateData(values);
+  }
 
 // ignore: deprecated_member_use
-Future<UserModel> getUserById(String id) => _firestore.collection(collection).document(id).get().then((doc){
-  return UserModel.fromSnapshot(doc);
-});
-
+  Future<UserModel> getUserById(String id) =>
+      _firestore.collection(collection).doc(id).get().then((doc) {
+        return UserModel.fromSnapshot(doc);
+      });
 }


### PR DESCRIPTION
1) Removed changenotifierprovider.value as you do not need an instance of one value but rather an instance of the entire class
2) Removed case where status is uninitialized, if you're a first time user, you will never get past this part
3) Firestore is deprecated, replaced it with FirebaseFirestore